### PR TITLE
[RELEASE] JSToast/2.8.1

### DIFF
--- a/Sources/JSToast/Toast/Util/ContentResponderWindow.swift
+++ b/Sources/JSToast/Toast/Util/ContentResponderWindow.swift
@@ -1,8 +1,8 @@
 //
 //  ContentResponderWindow.swift
-//  
 //
-//  Created by JSilver on 2023/02/11.
+//
+//  Created by jsilver on 2023/02/11.
 //
 
 import UIKit
@@ -39,12 +39,32 @@ class ContentResponderWindow: UIWindow {
     
     // MARK: - Lifecycle
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        let view = super.hitTest(point, with: event)
-        guard view != rootViewController?.view else { return nil }
-        return view
+        if #available(iOS 18, *) {
+            let view = super.hitTest(point, with: event)
+            guard let view, _hitTest(point, from: view) != rootViewController?.view else { return nil }
+            return view
+        } else {
+            let view = super.hitTest(point, with: event)
+            guard view != rootViewController?.view else { return nil }
+            return view
+        }
     }
     
     // MARK: - Public
     
     // MARK: - Private
+    private func _hitTest(_ point: CGPoint, from view: UIView) -> UIView? {
+        let converted = convert(point, to: view)
+        
+        guard view.bounds.contains(converted)
+            && view.isUserInteractionEnabled
+            && !view.isHidden
+            && view.alpha > 0
+        else { return nil }
+        
+        return view.subviews.reversed()
+            .reduce(Optional<UIView>.none) { result, view in
+                result ?? _hitTest(point, from: view)
+            } ?? view
+    }
 }


### PR DESCRIPTION
…Window` behaves unexpectedly on iOS 18+

# 📌 Reference
> Add any references help for understand this pull request.


# 🔥 Cause
> If there is a reason, write why the code changes was occurred.


# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

### Fixed
- Fixed an issue where the `hitTest(_:with:)` of `ContentResponderWindow` behaves unexpectedly on iOS 18+. see relative [issue](https://forums.developer.apple.com/forums/thread/762292).

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.
